### PR TITLE
fix(shared): add default value for hour parameter in formatDateHour

### DIFF
--- a/packages/shared/src/formats/formatDateHour.ts
+++ b/packages/shared/src/formats/formatDateHour.ts
@@ -1,6 +1,6 @@
 import { regex } from "../validations/regex";
 
-function formatDateHour(date: string, hour: string) {
+function formatDateHour(date: string, hour: string = "00:00") {
   if (regex.HOUR.test(hour) === false) throw new Error("Invalid hour format");
 
   const dateHour = new Date(date);


### PR DESCRIPTION
The formatDateHour function now has a default value of "00:00" for the hour parameter, improving its flexibility and ease of use when only a date is provided.